### PR TITLE
Update wiki URL

### DIFF
--- a/changes/index.html
+++ b/changes/index.html
@@ -48,7 +48,7 @@
 						Wiki
 						<div class="dropdown-content">
 						  <a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-						  <a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+						  <a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 						</div>
 					  </div>
 					</div>
@@ -65,7 +65,7 @@
 					<a href="../socials">Socials</a><a target="_blank" href="https://store.modernbeta.org/">Store</a>
 					<a target="_blank" href="https://map.modernbeta.org">Map</a>
 					<a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-					<a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+					<a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 				</div>
 			</div>
 		</nav>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 						Wiki
 						<div class="dropdown-content">
 						  <a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-						  <a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+						  <a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 						</div>
 					  </div>
 					</div>
@@ -63,7 +63,7 @@
 					<a href="socials">Socials</a><a target="_blank" href="https://store.modernbeta.org/">Store</a>
 					<a target="_blank" href="https://map.modernbeta.org">Map</a>
 					<a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-					<a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+					<a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 				</div>
 			</div>
 		</nav>

--- a/play/index.html
+++ b/play/index.html
@@ -45,7 +45,7 @@
 						Wiki
 						<div class="dropdown-content">
 						  <a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-						  <a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+						  <a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 						</div>
 					  </div>
 					</div>
@@ -62,7 +62,7 @@
 					<a href="../socials">Socials</a><a target="_blank" href="https://store.modernbeta.org/">Store</a>
 					<a target="_blank" href="https://map.modernbeta.org">Map</a>
 					<a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-					<a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+					<a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 				</div>
 			</div>
 		</nav>

--- a/rules/index.html
+++ b/rules/index.html
@@ -45,7 +45,7 @@
 						Wiki
 						<div class="dropdown-content">
 						  <a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-						  <a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+						  <a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 						</div>
 					  </div>
 					</div>
@@ -62,7 +62,7 @@
 					<a href="../socials">Socials</a><a target="_blank" href="https://store.modernbeta.org/">Store</a>
 					<a target="_blank" href="https://map.modernbeta.org">Map</a>
 					<a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-					<a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+					<a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 				</div>
 			</div>
 		</nav>

--- a/socials/index.html
+++ b/socials/index.html
@@ -45,7 +45,7 @@
 						Wiki
 						<div class="dropdown-content">
 						  <a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-						  <a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+						  <a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 						</div>
 					  </div>
 					</div>
@@ -62,7 +62,7 @@
 					<a href="../socials">Socials</a><a target="_blank" href="https://store.modernbeta.org/">Store</a>
 					<a target="_blank" href="https://map.modernbeta.org">Map</a>
 					<a target="_blank" href="https://web.archive.org/web/20110902065819/http://www.minecraftwiki.net:80/wiki/Minecraft_Wiki">Beta 1.7.3 Wiki</a>
-					<a target="_blank" href="https://modernbeta.miraheze.org/wiki/Main_Page">Community Wiki</a>
+					<a target="_blank" href="https://wiki.modernbeta.org/">Community Wiki</a>
 				</div>
 			</div>
 		</nav>


### PR DESCRIPTION
Now that the wiki is officially hosted on https://wiki.modernbeta.org, this PR updates those links